### PR TITLE
Fix offline build issues

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,6 @@ const nextConfig = {
     webVitalsAttribution: ['CLS', 'LCP']
   },
   // Enable service worker
-  swcMinify: true,
   // Optimize for mobile
   compress: true,
   // Enable static optimization

--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -19,7 +19,7 @@ export const OfflineIndicator: React.FC<Props> = ({ isOffline }) => {
         >
           <div className="flex items-center justify-center gap-2 text-sm font-medium">
             <ExclamationTriangleIcon className="w-4 h-4" />
-            <span>You're offline - some features may be limited</span>
+            <span>You&apos;re offline - some features may be limited</span>
             <WifiIcon className="w-4 h-4 opacity-50" />
           </div>
         </motion.div>


### PR DESCRIPTION
## Summary
- escape apostrophe in `OfflineIndicator`
- remove deprecated `swcMinify` option from `next.config.js`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a76d3ad94832993204fb43951de1d