### PR TITLE
Fix background sync typing

### DIFF
--- a/src/lib/offlineStorage.ts
+++ b/src/lib/offlineStorage.ts
@@ -119,7 +119,7 @@ export class OfflineQueue {
     // Register background sync if available
     if ('serviceWorker' in navigator && 'sync' in window.ServiceWorkerRegistration.prototype) {
       try {
-        const registration = await navigator.serviceWorker.ready;
+        const registration = (await navigator.serviceWorker.ready) as ServiceWorkerRegistration & { sync: SyncManager };
         await registration.sync.register('background-sync-posts');
       } catch (error) {
         console.error('Background sync registration failed:', error);
@@ -140,7 +140,7 @@ export class OfflineQueue {
     // Register background sync if available
     if ('serviceWorker' in navigator && 'sync' in window.ServiceWorkerRegistration.prototype) {
       try {
-        const registration = await navigator.serviceWorker.ready;
+        const registration = (await navigator.serviceWorker.ready) as ServiceWorkerRegistration & { sync: SyncManager };
         await registration.sync.register('background-sync-messages');
       } catch (error) {
         console.error('Background sync registration failed:', error);

--- a/src/service-worker.d.ts
+++ b/src/service-worker.d.ts
@@ -1,0 +1,9 @@
+interface SyncManager {
+  register(tag: string): Promise<void>;
+}
+
+interface ServiceWorkerRegistration {
+  readonly sync: SyncManager;
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a Service Worker type declaration for the SyncManager API
- cast ServiceWorkerRegistration to include sync before registering background tasks

## Testing
- `npx tsc --noEmit --skipLibCheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686a8abad6488329824a7b8983605a31