### PR TITLE
Fix location coordinate handling

### DIFF
--- a/src/components/common/PermissionDeniedBanner.tsx
+++ b/src/components/common/PermissionDeniedBanner.tsx
@@ -48,7 +48,7 @@ export const PermissionDeniedBanner: React.FC<Props> = ({
             </div>
           </div>
           <p className="text-xs text-red-200 mt-2">
-            Please enable location permissions in your device's app settings or browser settings to use this feature.
+            Please enable location permissions in your device&apos;s app settings or browser settings to use this feature.
           </p>
         </motion.div>
       )}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -42,11 +42,11 @@ export const FILE_LIMITS = {
     MAX_SIZE_MB: 10,
     FORMATS: ['image/jpeg', 'image/png', 'image/webp'],
     COMPRESSION: {
-      MIN_SIZE_KB: 350,
-      MAX_SIZE_KB: 800,
-      MAX_WIDTH: 1920,
-      MAX_HEIGHT: 1920,
-    },
+      minSizeKB: 350,
+      maxSizeKB: 800,
+      maxWidth: 1920,
+      maxHeight: 1920,
+    } as const,
   },
 } as const;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,14 @@
 import { supabase, ensureSession } from './supabase'
-import { executeAuthOperation, validateAuthInput, handleAuthError } from '../utils/auth'
+import {
+  executeAuthOperation,
+  validateAuthInput,
+  handleAuthError
+} from '../utils/auth'
 import { UI_CONFIG } from '../constants'
 
-export type { AuthResponse } from '../utils/auth'
+import type { AuthResponse } from '../utils/auth'
+
+export type { AuthResponse }
 
 // Check if Supabase is available
 const isSupabaseAvailable = (): boolean => {

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -190,8 +190,10 @@ export const saveUserLocation = async (
     console.log('Saving user location to profile:', userId, location);
 
     // Round coordinates to 2 decimal places before saving
-    const latRounded = Number(location.latitude.toFixed(2));
-    const lonRounded = Number(location.longitude.toFixed(2));
+    const latVal = typeof location.latitude === 'string' ? parseFloat(location.latitude) : location.latitude;
+    const lonVal = typeof location.longitude === 'string' ? parseFloat(location.longitude) : location.longitude;
+    const latRounded = Number(latVal.toFixed(2));
+    const lonRounded = Number(lonVal.toFixed(2));
 
     const { error } = await supabase
       .from('profiles')
@@ -228,10 +230,14 @@ export const hasLocationChanged = (
   oldLocation: UserLocation,
   newLocation: UserLocation
 ): boolean => {
-  const oldLatRounded = Number(oldLocation.latitude.toFixed(2));
-  const oldLonRounded = Number(oldLocation.longitude.toFixed(2));
-  const newLatRounded = Number(newLocation.latitude.toFixed(2));
-  const newLonRounded = Number(newLocation.longitude.toFixed(2));
+  const oldLat = typeof oldLocation.latitude === 'string' ? parseFloat(oldLocation.latitude) : oldLocation.latitude;
+  const oldLon = typeof oldLocation.longitude === 'string' ? parseFloat(oldLocation.longitude) : oldLocation.longitude;
+  const newLat = typeof newLocation.latitude === 'string' ? parseFloat(newLocation.latitude) : newLocation.latitude;
+  const newLon = typeof newLocation.longitude === 'string' ? parseFloat(newLocation.longitude) : newLocation.longitude;
+  const oldLatRounded = Number(oldLat.toFixed(2));
+  const oldLonRounded = Number(oldLon.toFixed(2));
+  const newLatRounded = Number(newLat.toFixed(2));
+  const newLonRounded = Number(newLon.toFixed(2));
   
   return oldLatRounded !== newLatRounded || oldLonRounded !== newLonRounded;
 };
@@ -270,8 +276,16 @@ export const getNearbyUsers = async (
     console.log('📍 Limit:', limit);
 
     // Round coordinates to 2 decimal places for exact matching
-    const latRounded = Number(currentLocation.latitude.toFixed(2));
-    const lonRounded = Number(currentLocation.longitude.toFixed(2));
+    const latValue =
+      typeof currentLocation.latitude === 'string'
+        ? parseFloat(currentLocation.latitude)
+        : currentLocation.latitude;
+    const lonValue =
+      typeof currentLocation.longitude === 'string'
+        ? parseFloat(currentLocation.longitude)
+        : currentLocation.longitude;
+    const latRounded = Number(latValue.toFixed(2));
+    const lonRounded = Number(lonValue.toFixed(2));
 
     console.log('📍 Rounded coordinates for matching:', { latRounded, lonRounded });
 
@@ -289,8 +303,10 @@ export const getNearbyUsers = async (
     } else {
       console.log('🔍 DEBUG: Found', allUsersWithLocation?.length || 0, 'users with location data');
       allUsersWithLocation?.forEach((user: any, index: number) => {
-        const userLatRounded = Number(user.latitude.toFixed(2));
-        const userLonRounded = Number(user.longitude.toFixed(2));
+        const userLat = typeof user.latitude === 'string' ? parseFloat(user.latitude) : user.latitude;
+        const userLon = typeof user.longitude === 'string' ? parseFloat(user.longitude) : user.longitude;
+        const userLatRounded = Number(userLat.toFixed(2));
+        const userLonRounded = Number(userLon.toFixed(2));
         console.log(`🔍 DEBUG: User ${index + 1}: ${user.name} - Lat: ${user.latitude} (${userLatRounded}), Lon: ${user.longitude} (${userLonRounded})`);
         
         if (userLatRounded === latRounded && userLonRounded === lonRounded) {
@@ -317,8 +333,10 @@ export const getNearbyUsers = async (
       
       // Filter users with matching coordinates
       const matchingUsers = directMatchUsers?.filter((user: any) => {
-        const userLatRounded = Number(user.latitude.toFixed(2));
-        const userLonRounded = Number(user.longitude.toFixed(2));
+        const userLat = typeof user.latitude === 'string' ? parseFloat(user.latitude) : user.latitude;
+        const userLon = typeof user.longitude === 'string' ? parseFloat(user.longitude) : user.longitude;
+        const userLatRounded = Number(userLat.toFixed(2));
+        const userLonRounded = Number(userLon.toFixed(2));
         const matches = userLatRounded === latRounded && userLonRounded === lonRounded;
         
         console.log(`🔍 DEBUG: Checking ${user.name}: ${userLatRounded} === ${latRounded} && ${userLonRounded} === ${lonRounded} = ${matches}`);

--- a/src/screens/FeedbackScreen.tsx
+++ b/src/screens/FeedbackScreen.tsx
@@ -20,7 +20,7 @@ export const FeedbackScreen: React.FC = () => {
     return handleSubmit();
   });
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
     
     if (!feedback.trim()) {


### PR DESCRIPTION
## Summary
- handle numeric strings for user location values
- parse latitude/longitude before rounding when checking or querying

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_687a7199b6448329b866ceedcdd7ddf7