### PR TITLE
Fix lint error in PermissionDeniedBanner

### DIFF
--- a/src/components/common/PermissionDeniedBanner.tsx
+++ b/src/components/common/PermissionDeniedBanner.tsx
@@ -48,7 +48,7 @@ export const PermissionDeniedBanner: React.FC<Props> = ({
             </div>
           </div>
           <p className="text-xs text-red-200 mt-2">
-            Please enable location permissions in your device's app settings or browser settings to use this feature.
+            Please enable location permissions in your device&apos;s app settings or browser settings to use this feature.
           </p>
         </motion.div>
       )}


### PR DESCRIPTION
## Summary
- fix unescaped apostrophe in `PermissionDeniedBanner`

## Testing
- `npm install` *(fails: unable to access registry)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a8366be0083298d9d0e7e2532f1b1