### PR TITLE
Fix missing icon dependencies

### DIFF
--- a/src/components/radar/RadarUserCard.tsx
+++ b/src/components/radar/RadarUserCard.tsx
@@ -1,7 +1,80 @@
 import React, { useState } from 'react';
 import { User } from '../../types';
-import { IconBrandInstagram, IconBrandLinkedin, IconBrandX } from '@tabler/icons-react';
-import { ChatBubbleLeftIcon, UserIcon, MapPinIcon } from '@heroicons/react/24/outline';
+// The project repository does not include external icon libraries.  Define
+// minimal inline SVG icons here so this component can render without those
+// dependencies.
+const IconBrandInstagram: React.FC<{ size?: number; className?: string }> = ({
+  size = 18,
+  className
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+  >
+    <rect x="3" y="3" width="18" height="18" rx="5" stroke="currentColor" strokeWidth="2" fill="none" />
+    <circle cx="12" cy="12" r="4" />
+  </svg>
+);
+
+const IconBrandLinkedin: React.FC<{ size?: number; className?: string }> = ({
+  size = 18,
+  className
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+  >
+    <rect x="4" y="4" width="16" height="16" rx="2" stroke="currentColor" strokeWidth="2" fill="none" />
+    <rect x="7" y="10" width="2" height="6" fill="currentColor" />
+    <rect x="11" y="10" width="6" height="2" fill="currentColor" />
+  </svg>
+);
+
+const IconBrandX: React.FC<{ size?: number; className?: string }> = ({
+  size = 18,
+  className
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+  >
+    <path d="M4 4l16 16M20 4L4 20" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);
+
+const ChatBubbleLeftIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    width={20}
+    height={20}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+  >
+    <path d="M4 5h16v10H6l-2 2V5z" stroke="currentColor" strokeWidth="2" fill="none" />
+  </svg>
+);
+
+const UserIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    width={20}
+    height={20}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    className={className}
+  >
+    <circle cx="12" cy="8" r="4" stroke="currentColor" strokeWidth="2" fill="none" />
+    <path d="M4 20c0-4 4-6 8-6s8 2 8 6" stroke="currentColor" strokeWidth="2" fill="none" />
+  </svg>
+);
 import { UserProfileModal } from './UserProfileModal';
 
 interface Props {


### PR DESCRIPTION
## Summary
- drop external icon library imports
- inline minimal SVG icons for RadarUserCard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b420e1368832980144dc49a50994d