### PR TITLE
Fix unescaped quotes in RadarScreen

### DIFF
--- a/src/screens/RadarScreen.tsx
+++ b/src/screens/RadarScreen.tsx
@@ -627,7 +627,7 @@ export const RadarScreen: React.FC<Props> = ({
                       </div>
                       <p className="text-gray-400 mb-2">No users found</p>
                       <p className="text-gray-500 text-sm mb-4">
-                        No users match "{searchQuery}". Try a different search term.
+                        No users match &quot;{searchQuery}&quot;. Try a different search term.
                       </p>
                       <button
                         onClick={clearSearch}


### PR DESCRIPTION
## Summary
- escape quotes around the search query to fix linting error

## Testing
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b8e2e542c832982c9a25f5092b595