### PR TITLE
Fix avatar src fallbacks

### DIFF
--- a/src/components/messaging/ChatWindow.tsx
+++ b/src/components/messaging/ChatWindow.tsx
@@ -146,9 +146,9 @@ export const ChatWindow = ({
         {chatMessages.length === 0 ? (
           <div className="flex items-center justify-center h-full">
             <div className="text-center">
-              <img 
-                src={user.dpUrl} 
-                alt={user.name} 
+              <img
+                src={user.dpUrl ?? '/images/default-avatar.png'}
+                alt={user.name}
                 className="w-16 h-16 rounded-full mx-auto mb-4"
               />
               <p className="text-gray-400">Start a conversation with {user.name}</p>

--- a/src/screens/EditProfileScreen.tsx
+++ b/src/screens/EditProfileScreen.tsx
@@ -25,7 +25,7 @@ export const EditProfileScreen: React.FC<Props> = ({ user, onBack, onSave, initi
     twitterUrl: user.twitterUrl,
   });
   const [profileFile, setProfileFile] = useState<File | null>(null);
-  const [profileUrl, setProfileUrl] = useState<string>(user.dpUrl);
+  const [profileUrl, setProfileUrl] = useState<string>(user.dpUrl || '');
   const [coverFile, setCoverFile] = useState<File | null>(null);
   const [coverUrl, setCoverUrl] = useState<string>(user.coverPhotoUrl || '');
   const [loading, setLoading] = useState<boolean>(false);

--- a/src/screens/PostsGalleryScreen.tsx
+++ b/src/screens/PostsGalleryScreen.tsx
@@ -81,7 +81,7 @@ export const PostsGalleryScreen: React.FC<Props> = ({
           </button>
           <div className="flex items-center">
             <img
-              src={user.dpUrl}
+              src={user.dpUrl ?? '/images/default-avatar.png'}
               alt={user.name}
               className="w-8 h-8 rounded-full object-cover ring-2 ring-blue-500 mr-3"
             />


### PR DESCRIPTION
## Summary
- ensure default avatar when user.dpUrl is null in ChatWindow empty conversation block
- use same fallback for PostsGalleryScreen header

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a40c2aad48329bbdbd07dee0869fa