### PR TITLE
feat: add service worker for supabase auth with offline fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ yarn-error.log*
 next-env.d.ts
 
 # PWA files
-/public/sw.js
 /public/workbox-*.js
 /public/worker-*.js
 /public/sw.js.map

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,42 @@
+const CACHE_NAME = 'offline-cache-v1';
+const OFFLINE_URL = '/offline.html';
+const AUTH_PREFIX = 'supabase.co/auth/v1/';
+const RETRY_LIMIT = 1; // small retry limit
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll([OFFLINE_URL]))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+async function networkFirstWithRetry(request) {
+  for (let attempt = 0; attempt <= RETRY_LIMIT; attempt++) {
+    try {
+      return await fetch(request);
+    } catch (err) {
+      if (attempt === RETRY_LIMIT) {
+        return caches.match(OFFLINE_URL);
+      }
+    }
+  }
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.url.includes(AUTH_PREFIX)) {
+    event.respondWith(networkFirstWithRetry(request));
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() => caches.match(OFFLINE_URL))
+    );
+  }
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,8 @@ export default function App() {
     
     // Register service worker
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js')
+      navigator.serviceWorker
+        .register('/sw.js', { scope: '/' })
         .then((registration) => {
           console.log('Service Worker registered successfully:', registration);
         })


### PR DESCRIPTION
## Summary
- add service worker with network-first handling for Supabase auth requests and offline fallback
- register service worker with root scope in `App.tsx`
- allow tracking of `public/sw.js`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `curl -I http://localhost:3000/sw.js`


------
https://chatgpt.com/codex/tasks/task_e_689455d85260832983c4a6a427f56ddd