### PR TITLE
Handle session storage fallback during signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ Make sure to set these in your deployment platform:
 ### Progressive Web App
 The project is configured as a PWA using `next-pwa`. When built for production, the app can be installed on mobile devices and works offline.
 
+#### Session persistence fallback
+During signup the app tries to save the authentication session to `localStorage` so it survives a reload. If the browser blocks storage, the session is kept only in memory and you'll be prompted to finish signup in a regular browser window.
+
 ## 🔮 Future Enhancements
 
 - **Real-time Messaging** - WebSocket integration

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -173,6 +173,21 @@ export const verifySignupOTP = async (email: string, token: string): Promise<Aut
     // Ensure session is properly stored
     if (data.session) {
       await supabase!.auth.setSession(data.session)
+      try {
+        const key = 'supabase.auth.token'
+        const stored = localStorage.getItem(key)
+        if (!stored) {
+          localStorage.setItem(key, JSON.stringify(data.session))
+        }
+        // Verify we can read and parse the session after write
+        JSON.parse(localStorage.getItem(key) || '')
+      } catch (err) {
+        console.warn('Session persistence to localStorage failed, using in-memory token', err)
+        if (typeof window !== 'undefined') {
+          ;(window as any).__supabaseSession = data.session
+          alert('We could not save your session. Please finish signup in your browser.')
+        }
+      }
     }
 
     console.log('OTP verified successfully, user created:', data.user.id)


### PR DESCRIPTION
## Summary
- confirm Supabase signup session is persisted to localStorage and readable after reload
- fall back to in-memory token and prompt user when storage fails
- document session fallback in PWA onboarding section

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68945e954b988329844d52a5d3c3578f