### PR TITLE
fix: escape unescaped characters

### DIFF
--- a/src/components/social/SocialLinksModal.tsx
+++ b/src/components/social/SocialLinksModal.tsx
@@ -279,7 +279,7 @@ export const SocialLinksModal: React.FC<Props> = ({
           <div className="bg-blue-900/20 border border-blue-700/50 rounded-lg p-3 mt-6">
             <h3 className="text-sm font-medium text-blue-300 mb-1">How it works</h3>
             <p className="text-xs text-blue-200">
-              Enter your social media URLs and they'll be validated automatically. Changes are saved to your profile when you click "Save" in the main edit screen.
+              Enter your social media URLs and they&apos;ll be validated automatically. Changes are saved to your profile when you click &quot;Save&quot; in the main edit screen.
             </p>
           </div>
         </div>

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -773,7 +773,7 @@ export const LoginScreen: React.FC<Props> = ({ onLogin }) => {
         <div className="fixed inset-0 bg-black/80 flex items-center justify-center p-4 z-50">
           <div className="bg-gray-900 border border-gray-700 rounded-xl p-6 text-center max-w-sm w-full">
             <p className="text-gray-300 mb-4">
-              We're having trouble verifying your connection. For your safety, please retry in the browser.
+              We&apos;re having trouble verifying your connection. For your safety, please retry in the browser.
             </p>
             <div className="space-y-2">
               <button


### PR DESCRIPTION
## Summary
- escape quotes and apostrophes in SocialLinksModal info message
- escape apostrophe in LoginScreen fallback message

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894835727708329858cb94bb430e6bc