### PR TITLE
refactor ChatWindow to use parent message props

### DIFF
--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -242,10 +242,26 @@ export const MessagesScreen: React.FC<Props> = ({
     if (!selectedUser) return;
     if (!isValidUuid(currentUserId)) return;
 
-    const newMessage = await sendMessage(currentUserId, selectedUser.id, content);
-    if (newMessage) {
-      setAllMessages(prev => [...prev, newMessage]);
-      setUnreadByUser((prev) => ({ ...prev, [selectedUser.id]: false }));
+    const tempId = `temp-${Date.now()}`;
+    const tempMessage: Message = {
+      id: tempId,
+      senderId: currentUserId,
+      receiverId: selectedUser.id,
+      content,
+      timestamp: new Date().toISOString(),
+      read: true,
+    };
+
+    setAllMessages(prev => [...prev, tempMessage]);
+    setUnreadByUser(prev => ({ ...prev, [selectedUser.id]: false }));
+
+    const saved = await sendMessage(currentUserId, selectedUser.id, content);
+    if (saved) {
+      setAllMessages(prev =>
+        prev.map(m => (m.id === tempId ? saved : m))
+      );
+    } else {
+      setAllMessages(prev => prev.filter(m => m.id !== tempId));
     }
   };
 


### PR DESCRIPTION
## Summary
- delegate ChatWindow message sending to parent via `onSendMessage`
- accept `messages` prop and hydrate local state
- optimistically merge messages in `MessagesScreen`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b564710248329814b30fff37a12c4